### PR TITLE
Use environment's $GOPATH if set

### DIFF
--- a/compiler/golang.vim
+++ b/compiler/golang.vim
@@ -75,7 +75,9 @@ au CursorMoved <buffer> call s:GetGolangMessage()
 if exists('golang_goroot')
   let $GOROOT=golang_goroot
 endif
-let $GOPATH=substitute(expand("%:p:h"),"\\(.*\\)/src.*","\\1",'g')
+if empty($GOPATH)
+    let $GOPATH=substitute(expand("%:p:h"),"\\(.*\\)/src.*","\\1",'g')
+endif
 let $PATHESCAPED=substitute(expand("%:p:h"),"\/","\\\\/",'g')
 CompilerSet makeprg=cd\ %:p:h;\ $GOROOT/bin/go\ build\ 2>&1\\\|sed\ -e\ \'s\/^\\(.*\\)\.go/$PATHESCAPED\\/\\1.go\/g\'
 CompilerSet efm=%f:%l:%m


### PR DESCRIPTION
My $GOPATH is different, the plugin fails to find imports with the existing logic. This patch checks if $GOPATH is set, if not reverts to the current way.
